### PR TITLE
Switch to using synchronous API for anything touching the filesystem

### DIFF
--- a/src/lib/cleanOutputDirectory.ts
+++ b/src/lib/cleanOutputDirectory.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
-import * as fs from 'fs/promises';
-import * as fsSync from 'fs';
+import * as fs from 'fs';
 
 import { scanDirectory } from '../utils/fs';
 
@@ -45,7 +44,7 @@ export function cleanOutputDirectory(
     // TODO: This `file.isEmpty` is ducktape over folders with similar name problem.
     // It will eventually delete the empty file, on 2nd build when watching.
     if (!expectedOutputPathsThatStartWithFilePath || file.isEmpty) {
-      fsSync.rmSync(file.path, { recursive: true });
+      fs.rmSync(file.path, { recursive: true });
     }
   });
 }

--- a/src/lib/cleanOutputDirectory.ts
+++ b/src/lib/cleanOutputDirectory.ts
@@ -32,7 +32,7 @@ export function cleanOutputDirectory(
     assets
   ).map((outputPath) => path.join(outputDirectory, outputPath));
 
-  scanDirectory(outputDirectory, [], async (file) => {
+  scanDirectory(outputDirectory, [], (file) => {
     // TODO: Rename this long variable.
     const expectedOutputPathsThatStartWithFilePath = expectedOutputPaths.find(
       (expectedOutputPath) => {

--- a/src/lib/cleanOutputDirectory.ts
+++ b/src/lib/cleanOutputDirectory.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import * as fsSync from 'fs';
 
 import { scanDirectory } from '../utils/fs';
 
@@ -21,7 +22,7 @@ function getExpectedOutputPaths(
 /**
  * Remove files from output directory that are not expected to be there from built pages or copied assets.
  */
-export async function cleanOutputDirectory(
+export function cleanOutputDirectory(
   outputDirectory: string,
   pages: Page[],
   assets: Asset[]
@@ -32,7 +33,7 @@ export async function cleanOutputDirectory(
     assets
   ).map((outputPath) => path.join(outputDirectory, outputPath));
 
-  await scanDirectory(outputDirectory, [], async (file) => {
+  scanDirectory(outputDirectory, [], async (file) => {
     // TODO: Rename this long variable.
     const expectedOutputPathsThatStartWithFilePath = expectedOutputPaths.find(
       (expectedOutputPath) => {
@@ -44,7 +45,7 @@ export async function cleanOutputDirectory(
     // TODO: This `file.isEmpty` is ducktape over folders with similar name problem.
     // It will eventually delete the empty file, on 2nd build when watching.
     if (!expectedOutputPathsThatStartWithFilePath || file.isEmpty) {
-      await fs.rm(file.path, { recursive: true });
+      fsSync.rmSync(file.path, { recursive: true });
     }
   });
 }

--- a/src/lib/getUserConfig.ts
+++ b/src/lib/getUserConfig.ts
@@ -24,8 +24,8 @@ const DEFAULT_CONFIG: Config = {
   getAssets: async () => []
 };
 
-export async function getUserConfig(configPath: string): Promise<Config> {
-  if (!(await checkFileExists(configPath))) {
+export function getUserConfig(configPath: string): Config {
+  if (!(checkFileExists(configPath))) {
     return DEFAULT_CONFIG;
   }
 

--- a/src/lib/getUserConfig.ts
+++ b/src/lib/getUserConfig.ts
@@ -25,7 +25,7 @@ const DEFAULT_CONFIG: Config = {
 };
 
 export function getUserConfig(configPath: string): Config {
-  if (!(checkFileExists(configPath))) {
+  if (!checkFileExists(configPath)) {
     return DEFAULT_CONFIG;
   }
 

--- a/src/lib/reloader.ts
+++ b/src/lib/reloader.ts
@@ -46,7 +46,6 @@ export function createReloader() {
       });
     });
 
-
     server.once('error', (err) => {
       if (err instanceof Error && err.code === 'EADDRINUSE') {
         port++;

--- a/src/lib/renderPages.ts
+++ b/src/lib/renderPages.ts
@@ -54,6 +54,7 @@ export async function renderPages(options: RenderPageOptions) {
   const renderedPages = [];
 
   for await (const page of options.pages) {
+    // Computed values is asynchronous because values can come from the network.
     const context: RenderContext = await withComputedValues<RenderContext>(
       ['data'],
       {

--- a/src/sources/getAssetsFromFS.ts
+++ b/src/sources/getAssetsFromFS.ts
@@ -16,9 +16,7 @@ function replaceStart(
   return replaceString + targetString.slice(searchValue.length);
 }
 
-export default function getAssetsFromFS(
-  options: AssetsOptions
-): Asset[] {
+export default function getAssetsFromFS(options: AssetsOptions): Asset[] {
   const files = scanDirectory(
     options.inputDirectory,
     options.ignorePathsAndDirectories

--- a/src/sources/getAssetsFromFS.ts
+++ b/src/sources/getAssetsFromFS.ts
@@ -16,10 +16,10 @@ function replaceStart(
   return replaceString + targetString.slice(searchValue.length);
 }
 
-export default async function getAssetsFromFS(
+export default function getAssetsFromFS(
   options: AssetsOptions
-): Promise<Asset[]> {
-  const files = await scanDirectory(
+): Asset[] {
+  const files = scanDirectory(
     options.inputDirectory,
     options.ignorePathsAndDirectories
   );

--- a/src/sources/getCollectionFromFS.ts
+++ b/src/sources/getCollectionFromFS.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs/promises';
+import * as fsSync from 'fs';
 import * as path from 'path';
 import * as markdown from 'markdown-wasm';
 
@@ -112,13 +113,13 @@ function getCommentPropsFromContent(content: string): [CommentProps, string] {
  * });
  * ```
  **/
-export default async function getCollectionFromFS(
+export default function getCollectionFromFS(
   options: CollectionOptions
-): Promise<Page[]> {
+): Page[] {
   const pages = [];
   const files = getDirectoryNames(options.inputDirectory);
 
-  for await (const file of files) {
+  for (const file of files) {
     const markdownFilePath = path.join(
       options.inputDirectory,
       file,
@@ -131,7 +132,7 @@ export default async function getCollectionFromFS(
       continue;
     }
 
-    const markdownFileContents = await fs.readFile(markdownFilePath, 'utf8');
+    const markdownFileContents = fsSync.readFileSync(markdownFilePath, 'utf8');
     const content = markdown.parse(markdownFileContents);
     const title = getTitleFromHTML(content);
     const date = getDateFromFilename(file);
@@ -151,7 +152,7 @@ export default async function getCollectionFromFS(
     // `./dist` directory be passed in and subtracted from the path?
     const url = outputDirectory.replace('./dist', '');
 
-    const assetPaths = await recursiveReadDirectory(
+    const assetPaths = recursiveReadDirectory(
       path.join(options.inputDirectory, file)
     );
     const assetsWithoutMarkdownFile = assetPaths.filter((assetPath) => {

--- a/src/sources/getCollectionFromFS.ts
+++ b/src/sources/getCollectionFromFS.ts
@@ -116,7 +116,7 @@ export default async function getCollectionFromFS(
   options: CollectionOptions
 ): Promise<Page[]> {
   const pages = [];
-  const files = await getDirectoryNames(options.inputDirectory);
+  const files = getDirectoryNames(options.inputDirectory);
 
   for await (const file of files) {
     const markdownFilePath = path.join(
@@ -124,7 +124,7 @@ export default async function getCollectionFromFS(
       file,
       'index.md'
     );
-    const doesMarkdownFileExist = await checkFileExists(markdownFilePath);
+    const doesMarkdownFileExist = checkFileExists(markdownFilePath);
 
     // Avoid any folders that have no markdown files.
     if (!doesMarkdownFileExist) {

--- a/src/sources/getCollectionFromFS.ts
+++ b/src/sources/getCollectionFromFS.ts
@@ -1,5 +1,4 @@
-import * as fs from 'fs/promises';
-import * as fsSync from 'fs';
+import * as fs from 'fs';
 import * as path from 'path';
 import * as markdown from 'markdown-wasm';
 
@@ -132,7 +131,7 @@ export default function getCollectionFromFS(
       continue;
     }
 
-    const markdownFileContents = fsSync.readFileSync(markdownFilePath, 'utf8');
+    const markdownFileContents = fs.readFileSync(markdownFilePath, 'utf8');
     const content = markdown.parse(markdownFileContents);
     const title = getTitleFromHTML(content);
     const date = getDateFromFilename(file);

--- a/src/sources/getFunctionsFromFS.ts
+++ b/src/sources/getFunctionsFromFS.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { checkFileExists, getFileNames, requireUncached } from '../utils/fs';
 
 export function getFunctionsFromFS(functionsDirectory: string) {
-  if (!(checkFileExists(functionsDirectory))) {
+  if (!checkFileExists(functionsDirectory)) {
     return {};
   }
 

--- a/src/sources/getFunctionsFromFS.ts
+++ b/src/sources/getFunctionsFromFS.ts
@@ -2,15 +2,15 @@ import * as path from 'path';
 
 import { checkFileExists, getFileNames, requireUncached } from '../utils/fs';
 
-export async function getFunctionsFromFS(functionsDirectory: string) {
+export function getFunctionsFromFS(functionsDirectory: string) {
   if (!(checkFileExists(functionsDirectory))) {
     return {};
   }
 
   const functions: { [name: string]: any } = {};
-  const functionFilenames = await getFileNames(functionsDirectory);
+  const functionFilenames = getFileNames(functionsDirectory);
 
-  for await (const functionFilename of functionFilenames) {
+  for (const functionFilename of functionFilenames) {
     const { name } = path.parse(functionFilename);
 
     // TODO: Find out why we need to use process.cwd() for require and not readFile.

--- a/src/sources/getFunctionsFromFS.ts
+++ b/src/sources/getFunctionsFromFS.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { checkFileExists, getFileNames, requireUncached } from '../utils/fs';
 
 export async function getFunctionsFromFS(functionsDirectory: string) {
-  if (!(await checkFileExists(functionsDirectory))) {
+  if (!(checkFileExists(functionsDirectory))) {
     return {};
   }
 

--- a/src/sources/getLayoutsFromFS.ts
+++ b/src/sources/getLayoutsFromFS.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import { checkFileExists, getFileNames } from '../utils/fs';
 
 export function getLayoutsFromFS(layoutsDirectory: string) {
-  if (!(checkFileExists(layoutsDirectory))) {
+  if (!checkFileExists(layoutsDirectory)) {
     return {};
   }
 

--- a/src/sources/getLayoutsFromFS.ts
+++ b/src/sources/getLayoutsFromFS.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs/promises';
 import { checkFileExists, getFileNames } from '../utils/fs';
 
 export async function getLayoutsFromFS(layoutsDirectory: string) {
-  if (!(await checkFileExists(layoutsDirectory))) {
+  if (!(checkFileExists(layoutsDirectory))) {
     return {};
   }
 

--- a/src/sources/getLayoutsFromFS.ts
+++ b/src/sources/getLayoutsFromFS.ts
@@ -1,20 +1,21 @@
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import * as fsSync from 'fs';
 
 import { checkFileExists, getFileNames } from '../utils/fs';
 
-export async function getLayoutsFromFS(layoutsDirectory: string) {
+export function getLayoutsFromFS(layoutsDirectory: string) {
   if (!(checkFileExists(layoutsDirectory))) {
     return {};
   }
 
   const layouts: { [name: string]: string } = {};
-  const layoutFilenames = await getFileNames(layoutsDirectory);
+  const layoutFilenames = getFileNames(layoutsDirectory);
 
-  for await (const layoutFilename of layoutFilenames) {
+  for (const layoutFilename of layoutFilenames) {
     const { name } = path.parse(layoutFilename);
     const layoutPath = path.join(layoutsDirectory, layoutFilename);
-    const content = await fs.readFile(layoutPath, 'utf8');
+    const content = fsSync.readFileSync(layoutPath, 'utf8');
 
     layouts[name] = content;
   }

--- a/src/sources/getLayoutsFromFS.ts
+++ b/src/sources/getLayoutsFromFS.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
-import * as fs from 'fs/promises';
-import * as fsSync from 'fs';
+import * as fs from 'fs';
 
 import { checkFileExists, getFileNames } from '../utils/fs';
 
@@ -15,7 +14,7 @@ export function getLayoutsFromFS(layoutsDirectory: string) {
   for (const layoutFilename of layoutFilenames) {
     const { name } = path.parse(layoutFilename);
     const layoutPath = path.join(layoutsDirectory, layoutFilename);
-    const content = fsSync.readFileSync(layoutPath, 'utf8');
+    const content = fs.readFileSync(layoutPath, 'utf8');
 
     layouts[name] = content;
   }

--- a/src/staticbuild.ts
+++ b/src/staticbuild.ts
@@ -32,12 +32,12 @@ function copyAssets(assets: Asset[]) {
   }
 }
 
-async function writePages(pages: Page[]) {
-  for await (const page of pages) {
+function writePages(pages: Page[]) {
+  for (const page of pages) {
     const outputDirectory = path.dirname(page.outputPath);
 
-    await fs.mkdir(outputDirectory, { recursive: true });
-    await fs.writeFile(page.outputPath, page.content, 'utf8');
+    fsSync.mkdirSync(outputDirectory, { recursive: true });
+    fsSync.writeFileSync(page.outputPath, page.content, 'utf8');
   }
 }
 

--- a/src/staticbuild.ts
+++ b/src/staticbuild.ts
@@ -1,5 +1,4 @@
-import * as fs from 'fs/promises';
-import * as fsSync from 'fs';
+import * as fs from 'fs';
 import * as path from 'path';
 
 import { getLayoutsFromFS } from './sources/getLayoutsFromFS';
@@ -28,7 +27,7 @@ interface StaticBuildOptions {
 // TODO: Decide where this should live.
 function copyAssets(assets: Asset[]) {
   for (const asset of assets) {
-    fsSync.cpSync(asset.inputPath, asset.outputPath);
+    fs.cpSync(asset.inputPath, asset.outputPath);
   }
 }
 
@@ -36,8 +35,8 @@ function writePages(pages: Page[]) {
   for (const page of pages) {
     const outputDirectory = path.dirname(page.outputPath);
 
-    fsSync.mkdirSync(outputDirectory, { recursive: true });
-    fsSync.writeFileSync(page.outputPath, page.content, 'utf8');
+    fs.mkdirSync(outputDirectory, { recursive: true });
+    fs.writeFileSync(page.outputPath, page.content, 'utf8');
   }
 }
 

--- a/src/staticbuild.ts
+++ b/src/staticbuild.ts
@@ -125,7 +125,7 @@ export default async function staticbuild(options: StaticBuildOptions) {
     console.timeEnd('write');
 
     console.time('clean');
-    await cleanOutputDirectory(options.outputDirectory, pages, allAssets);
+    cleanOutputDirectory(options.outputDirectory, pages, allAssets);
     console.timeEnd('clean');
   }
 

--- a/src/staticbuild.ts
+++ b/src/staticbuild.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs/promises';
+import * as fsSync from 'fs';
 import * as path from 'path';
 
 import { getLayoutsFromFS } from './sources/getLayoutsFromFS';
@@ -25,9 +26,9 @@ interface StaticBuildOptions {
 }
 
 // TODO: Decide where this should live.
-async function copyAssets(assets: Asset[]) {
-  for await (const asset of assets) {
-    await fs.cp(asset.inputPath, asset.outputPath);
+function copyAssets(assets: Asset[]) {
+  for (const asset of assets) {
+    fsSync.cpSync(asset.inputPath, asset.outputPath);
   }
 }
 
@@ -102,7 +103,7 @@ export default async function staticbuild(options: StaticBuildOptions) {
     // TODO: Clean up to not use ternary?
     const assetsToCopy = changedFilePaths.length ? filteredAssets : allAssets;
 
-    await copyAssets(assetsToCopy);
+    copyAssets(assetsToCopy);
 
     console.timeEnd('copy');
 

--- a/src/staticbuild.ts
+++ b/src/staticbuild.ts
@@ -47,7 +47,7 @@ export default async function staticbuild(options: StaticBuildOptions) {
   async function build(changedFilePaths: string[] = []) {
     console.time('setup');
     const env = getEnvironmentConfig();
-    const config = await getUserConfig(options.configPath);
+    const config = getUserConfig(options.configPath);
     const functions = await getFunctionsFromFS(config.directories.functions);
     // TODO: Add check for errors with data JSON formatting.
     const data = await getFunctionsFromFS(config.directories.data);

--- a/src/staticbuild.ts
+++ b/src/staticbuild.ts
@@ -48,12 +48,12 @@ export default async function staticbuild(options: StaticBuildOptions) {
     console.time('setup');
     const env = getEnvironmentConfig();
     const config = getUserConfig(options.configPath);
-    const functions = await getFunctionsFromFS(config.directories.functions);
+    const functions = getFunctionsFromFS(config.directories.functions);
     // TODO: Add check for errors with data JSON formatting.
-    const data = await getFunctionsFromFS(config.directories.data);
-    const layouts = await getLayoutsFromFS(config.directories.layouts);
+    const data = getFunctionsFromFS(config.directories.data);
+    const layouts = getLayoutsFromFS(config.directories.layouts);
     const partials = {
-      ...(await getLayoutsFromFS(config.directories.partials)),
+      ...getLayoutsFromFS(config.directories.partials),
       ...getBuiltInPartials()
     };
     // TODO: Tidy up this bit!
@@ -70,7 +70,7 @@ export default async function staticbuild(options: StaticBuildOptions) {
 
         return template;
       },
-      ...(await getFunctionsFromFS(config.directories.hooks))
+      ...getFunctionsFromFS(config.directories.hooks)
     };
     console.timeEnd('setup');
 

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -27,10 +27,10 @@ export function checkFileExists(filePath: string) {
 }
 
 /** Return names of all directories found at the specified path. */
-export async function getDirectoryNames(
+export function getDirectoryNames(
   directoryPath: string
-): Promise<string[]> {
-  const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+): string[] {
+  const entries = fsSync.readdirSync(directoryPath, { withFileTypes: true });
 
   return entries
     .filter((entry) => entry.isDirectory())

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -11,9 +11,9 @@ export function requireUncached<T>(module: string): T {
 }
 
 /** Returns `true` if a file exists, otherwise `false`. */
-export async function checkFileExists(filePath: string) {
+export function checkFileExists(filePath: string) {
   try {
-    await fs.access(filePath, constants.F_OK);
+    fsSync.accessSync(filePath, constants.F_OK);
     return true;
   } catch (err) {
     if (err instanceof Error) {

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -38,8 +38,8 @@ export function getDirectoryNames(
 }
 
 /** Return names of all files found at the specified directoryPath. */
-export async function getFileNames(directoryPath: string): Promise<string[]> {
-  const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+export function getFileNames(directoryPath: string): string[] {
+  const entries = fsSync.readdirSync(directoryPath, { withFileTypes: true });
 
   return entries
     .filter((entry) => entry.isFile())
@@ -115,16 +115,16 @@ export function scanDirectory(
 }
 
 // TODO: Remove this and replace?
-export async function recursiveReadDirectory(
+export function recursiveReadDirectory(
   directoryPath: string
-): Promise<string[]> {
-  async function scan(targetDirectoryPath: string) {
+): string[] {
+  function scan(targetDirectoryPath: string) {
     const files: string[] = [];
-    const entries = await fs.readdir(targetDirectoryPath, {
+    const entries = fsSync.readdirSync(targetDirectoryPath, {
       withFileTypes: true
     });
 
-    for await (const entry of entries) {
+    for (const entry of entries) {
       const entryPath = path.join(targetDirectoryPath, entry.name);
 
       if (IGNORED_FILES.includes(entry.name)) {
@@ -132,7 +132,7 @@ export async function recursiveReadDirectory(
       }
 
       if (entry.isDirectory()) {
-        const subDirectoryFiles = await scan(entryPath);
+        const subDirectoryFiles = scan(entryPath);
         files.push(...subDirectoryFiles);
       }
 
@@ -144,15 +144,15 @@ export async function recursiveReadDirectory(
     return files;
   }
 
-  return await scan(directoryPath);
+  return scan(directoryPath);
 }
 
-export async function deleteFiles(
+export function deleteFiles(
   filePaths: string[],
   expectedDirectoryToDeleteFrom: string,
   dryRun?: boolean
 ) {
-  for await (const filePath of filePaths) {
+  for (const filePath of filePaths) {
     const isFileInExpectedDirectory = filePath.includes(
       expectedDirectoryToDeleteFrom
     );
@@ -166,7 +166,7 @@ export async function deleteFiles(
     if (dryRun) {
       console.warn('[dry run] delete:', filePath);
     } else {
-      await fs.rm(filePath);
+      fsSync.rmSync(filePath);
     }
   }
 }

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -26,9 +26,7 @@ export function checkFileExists(filePath: string) {
 }
 
 /** Return names of all directories found at the specified path. */
-export function getDirectoryNames(
-  directoryPath: string
-): string[] {
+export function getDirectoryNames(directoryPath: string): string[] {
   const entries = fs.readdirSync(directoryPath, { withFileTypes: true });
 
   return entries
@@ -114,9 +112,7 @@ export function scanDirectory(
 }
 
 // TODO: Remove this and replace?
-export function recursiveReadDirectory(
-  directoryPath: string
-): string[] {
+export function recursiveReadDirectory(directoryPath: string): string[] {
   function scan(targetDirectoryPath: string) {
     const files: string[] = [];
     const entries = fs.readdirSync(targetDirectoryPath, {

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,5 +1,4 @@
-import * as fs from 'fs/promises';
-import * as fsSync from 'fs';
+import * as fs from 'fs';
 import { constants } from 'fs';
 import * as path from 'path';
 
@@ -13,7 +12,7 @@ export function requireUncached<T>(module: string): T {
 /** Returns `true` if a file exists, otherwise `false`. */
 export function checkFileExists(filePath: string) {
   try {
-    fsSync.accessSync(filePath, constants.F_OK);
+    fs.accessSync(filePath, constants.F_OK);
     return true;
   } catch (err) {
     if (err instanceof Error) {
@@ -30,7 +29,7 @@ export function checkFileExists(filePath: string) {
 export function getDirectoryNames(
   directoryPath: string
 ): string[] {
-  const entries = fsSync.readdirSync(directoryPath, { withFileTypes: true });
+  const entries = fs.readdirSync(directoryPath, { withFileTypes: true });
 
   return entries
     .filter((entry) => entry.isDirectory())
@@ -39,7 +38,7 @@ export function getDirectoryNames(
 
 /** Return names of all files found at the specified directoryPath. */
 export function getFileNames(directoryPath: string): string[] {
-  const entries = fsSync.readdirSync(directoryPath, { withFileTypes: true });
+  const entries = fs.readdirSync(directoryPath, { withFileTypes: true });
 
   return entries
     .filter((entry) => entry.isFile())
@@ -66,7 +65,7 @@ export function scanDirectory(
 
   function scan(currentTargetDirectory: string) {
     const files: File[] = [];
-    const entries = fsSync.readdirSync(currentTargetDirectory, {
+    const entries = fs.readdirSync(currentTargetDirectory, {
       withFileTypes: true
     });
 
@@ -120,7 +119,7 @@ export function recursiveReadDirectory(
 ): string[] {
   function scan(targetDirectoryPath: string) {
     const files: string[] = [];
-    const entries = fsSync.readdirSync(targetDirectoryPath, {
+    const entries = fs.readdirSync(targetDirectoryPath, {
       withFileTypes: true
     });
 
@@ -166,7 +165,7 @@ export function deleteFiles(
     if (dryRun) {
       console.warn('[dry run] delete:', filePath);
     } else {
-      fsSync.rmSync(filePath);
+      fs.rmSync(filePath);
     }
   }
 }


### PR DESCRIPTION
The synchronous `fs` library is faster than the asynchronous version. This change has a speed increase of around ~20-30%, with the biggest improvment happening when copying assets (`~250ms` to ~`150ms`).

The `getPages` and `getAssets` functions remain asynchronous because pages may be collected via using `fetch` or other asynchronous ways.